### PR TITLE
Update classroom Now Functioning

### DIFF
--- a/src/api/classroomData.js
+++ b/src/api/classroomData.js
@@ -24,7 +24,7 @@ const getClassrooms = (teacherId) =>
 
 const getSingleClassroom = (classroomId) =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/classroom.json?orderBy="firebaseKey"&equalTo="${classroomId}"`, {
+    fetch(`${endpoint}/classroom/${classroomId}.json`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/classroom/edit/[firebaseKey]/page.jsx
+++ b/src/app/classroom/edit/[firebaseKey]/page.jsx
@@ -6,22 +6,18 @@ import { getSingleClassroom } from '../../../../api/classroomData';
 import ClassroomForm from '../../../../components/forms/ClassroomForm';
 
 export default function EditClassroom({ params }) {
-  const { firebaseKey } = params;
   const [editFormData, setEditFormData] = useState({});
+
+  const { firebaseKey } = params;
   // console.log(editFormData);
 
-  // TODO: GET single classroom by id, set form data. Pass in id in dependency array.
   useEffect(() => {
     getSingleClassroom(firebaseKey).then(setEditFormData);
-    // FIXME: Line 17 logs an empty object.
-    // console.log(editFormData);
+    // console.log("Params: ", params);
+    // console.log("FirebaseKey: ", firebaseKey);
   }, [firebaseKey]);
 
-  return (
-    <div>
-      <ClassroomForm obj={editFormData} />
-    </div>
-  );
+  return <ClassroomForm obj={editFormData} />;
 }
 
 EditClassroom.propTypes = {

--- a/src/app/classroom/edit/[firebaseKey]/page.jsx
+++ b/src/app/classroom/edit/[firebaseKey]/page.jsx
@@ -8,11 +8,13 @@ import ClassroomForm from '../../../../components/forms/ClassroomForm';
 export default function EditClassroom({ params }) {
   const { firebaseKey } = params;
   const [editFormData, setEditFormData] = useState({});
-  console.log(editFormData);
+  // console.log(editFormData);
 
   // TODO: GET single classroom by id, set form data. Pass in id in dependency array.
   useEffect(() => {
     getSingleClassroom(firebaseKey).then(setEditFormData);
+    // FIXME: Line 17 logs an empty object.
+    // console.log(editFormData);
   }, [firebaseKey]);
 
   return (

--- a/src/app/classroom/edit/[firebaseKey]/page.jsx
+++ b/src/app/classroom/edit/[firebaseKey]/page.jsx
@@ -13,6 +13,7 @@ export default function EditClassroom({ params }) {
 
   useEffect(() => {
     getSingleClassroom(firebaseKey).then(setEditFormData);
+    // console.log("Saved form data: ", editFormData);
     // console.log("Params: ", params);
     // console.log("FirebaseKey: ", firebaseKey);
   }, [firebaseKey]);

--- a/src/components/forms/ClassroomForm.jsx
+++ b/src/components/forms/ClassroomForm.jsx
@@ -21,6 +21,7 @@ export default function ClassroomForm({ obj = initialFormState }) {
   const router = useRouter();
 
   useEffect(() => {
+    console.log(obj);
     if (obj.firebaseKey) setFormInput(obj);
   }, [obj, user]);
 

--- a/src/components/forms/ClassroomForm.jsx
+++ b/src/components/forms/ClassroomForm.jsx
@@ -23,12 +23,11 @@ export default function ClassroomForm({ obj = initialFormState }) {
   useEffect(() => {
     console.log('Obj received: ', obj);
     console.log('Firebase Key: ', obj.firebaseKey);
-    // FIXME: Code from if statement doesn't run after this line. The Firebase Key isn't being read.
     if (obj.firebaseKey) {
       console.log('Updating formInput with obj: ', obj);
       setFormInput(obj);
     }
-  }, [obj, user]);
+  }, [obj]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;

--- a/src/components/forms/ClassroomForm.jsx
+++ b/src/components/forms/ClassroomForm.jsx
@@ -23,7 +23,7 @@ export default function ClassroomForm({ obj = initialFormState }) {
   useEffect(() => {
     // console.log('Obj received: ', obj);
     // console.log('Firebase Key: ', obj.firebaseKey);
-    // console.log(obj);
+    // FIXME: Code from if statement doesn't run after this line. The Firebase Key isn't being read.
     if (obj.firebaseKey) {
       console.log('Updating formInput with obj: ', obj);
       setFormInput(obj);

--- a/src/components/forms/ClassroomForm.jsx
+++ b/src/components/forms/ClassroomForm.jsx
@@ -21,8 +21,13 @@ export default function ClassroomForm({ obj = initialFormState }) {
   const router = useRouter();
 
   useEffect(() => {
-    console.log(obj);
-    if (obj.firebaseKey) setFormInput(obj);
+    // console.log('Obj received: ', obj);
+    // console.log('Firebase Key: ', obj.firebaseKey);
+    // console.log(obj);
+    if (obj.firebaseKey) {
+      console.log('Updating formInput with obj: ', obj);
+      setFormInput(obj);
+    }
   }, [obj, user]);
 
   const handleChange = (e) => {

--- a/src/components/forms/ClassroomForm.jsx
+++ b/src/components/forms/ClassroomForm.jsx
@@ -21,8 +21,8 @@ export default function ClassroomForm({ obj = initialFormState }) {
   const router = useRouter();
 
   useEffect(() => {
-    // console.log('Obj received: ', obj);
-    // console.log('Firebase Key: ', obj.firebaseKey);
+    console.log('Obj received: ', obj);
+    console.log('Firebase Key: ', obj.firebaseKey);
     // FIXME: Code from if statement doesn't run after this line. The Firebase Key isn't being read.
     if (obj.firebaseKey) {
       console.log('Updating formInput with obj: ', obj);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updating a classroom now works. I had to create a discussion ticket after struggling trying to figure out the issue. [Here's the link to the discussion ticket,](https://github.com/orgs/nss-evening-web-development/discussions/1401), but I was able to resolve the issue of not seeing the form data pre-filled when trying to update a classroom by removing the query parameters since I know which firebaseKey to get direct access to a specific classroom.

The alternative solution was to adjust my async function, getSingleClassroom, to return the data as Object.values since Firebase returns an array of objects when using the orderBy query parameter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes a bug that was preventing me from getting the form fields to pre-fill the existing classroom data. Creating a updating a classroom fully functions.

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->
Run branch locally before merging.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
