### PR TITLE
Merge data

### DIFF
--- a/src/api/classroomData.js
+++ b/src/api/classroomData.js
@@ -63,4 +63,17 @@ const updateClassroom = (payload) =>
       .catch(reject);
   });
 
-export { getClassrooms, getSingleClassroom, createClassroom, updateClassroom };
+const deleteClassroom = (classroomId) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/classroom/${classroomId}.json`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json)
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+export { getClassrooms, getSingleClassroom, createClassroom, updateClassroom, deleteClassroom };

--- a/src/api/mergeData.js
+++ b/src/api/mergeData.js
@@ -11,7 +11,7 @@ const deleteClassroomStudentRelationship = (firebaseKey) =>
           deleteClassroom(firebaseKey).then(resolve);
         });
       })
-      .then(reject);
+      .catch(reject);
   });
 
 export default deleteClassroomStudentRelationship;

--- a/src/api/mergeData.js
+++ b/src/api/mergeData.js
@@ -1,0 +1,17 @@
+import { getStudentsByClassroomId, deleteSingleStudent } from './studentData';
+import { deleteClassroom } from './classroomData';
+
+const deleteClassroomStudentRelationship = (firebaseKey) =>
+  new Promise((resolve, reject) => {
+    getStudentsByClassroomId(firebaseKey)
+      .then((studentsArray) => {
+        const deleteStudentsPromise = studentsArray.map((student) => deleteSingleStudent(student.firebaseKey));
+
+        Promise.all(deleteStudentsPromise).then(() => {
+          deleteClassroom(firebaseKey).then(resolve);
+        });
+      })
+      .then(reject);
+  });
+
+export default deleteClassroomStudentRelationship;

--- a/src/app/classroom/manage/page.jsx
+++ b/src/app/classroom/manage/page.jsx
@@ -25,7 +25,7 @@ export default function Page() {
       {/* TODO: Render Classroom components dynamically. */}
       <div className="d-flex flex-row flex-wrap justify-content-center">
         {classrooms.map((classroom) => (
-          <ClassroomCard key={classroom.firebaseKey} classroomObj={classroom} />
+          <ClassroomCard key={classroom.firebaseKey} classroomObj={classroom} onUpdate={getAllClassrooms} />
         ))}
       </div>
     </div>

--- a/src/app/classroom/manage/page.jsx
+++ b/src/app/classroom/manage/page.jsx
@@ -22,10 +22,9 @@ export default function Page() {
     <div className="d-flex flex-column my-4 text-center">
       <h1 className="my-3">Manage Classrooms</h1>
 
-      {/* TODO: Render Classroom components dynamically. */}
       <div className="d-flex flex-row flex-wrap justify-content-center">
         {classrooms.map((classroom) => (
-          <ClassroomCard key={classroom.firebaseKey} classroomObj={classroom} onUpdate={getAllClassrooms} />
+          <ClassroomCard key={classroom.firebaseKey} classroomObj={classroom} />
         ))}
       </div>
     </div>

--- a/src/app/classroom/manage/page.jsx
+++ b/src/app/classroom/manage/page.jsx
@@ -24,7 +24,7 @@ export default function Page() {
 
       <div className="d-flex flex-row flex-wrap justify-content-center">
         {classrooms.map((classroom) => (
-          <ClassroomCard key={classroom.firebaseKey} classroomObj={classroom} />
+          <ClassroomCard key={classroom.firebaseKey} classroomObj={classroom} onUpdate={getAllClassrooms} />
         ))}
       </div>
     </div>

--- a/src/components/classrooms/ClassroomCard.jsx
+++ b/src/components/classrooms/ClassroomCard.jsx
@@ -3,8 +3,20 @@
 import React from 'react';
 import Card from 'react-bootstrap/Card';
 import PropTypes from 'prop-types';
+import { useRouter } from 'next/navigation';
+import deleteClassroomStudentRelationship from '../../api/mergeData';
 
 export default function ClassroomCard({ classroomObj }) {
+  const router = useRouter();
+
+  const deleteClassroomFromView = () => {
+    if (window.confirm(`Are you sure you want to delete ${classroomObj.classroom_name}? Deleting this classroom will also delete the students.`)) {
+      deleteClassroomStudentRelationship(classroomObj.firebaseKey).then(() => {
+        router.push(`/classroom/manage/`);
+      });
+    }
+  };
+
   return (
     <Card style={{ width: '18rem', backgroundColor: '#222', color: '#fff' }} className="m-3">
       <Card.Body>
@@ -14,7 +26,7 @@ export default function ClassroomCard({ classroomObj }) {
 
         <Card.Link href={`/classroom/${classroomObj.firebaseKey}`}>View</Card.Link>
         <Card.Link href={`/classroom/edit/${classroomObj.firebaseKey}`}>Edit</Card.Link>
-        <Card.Link href="#">Delete</Card.Link>
+        <Card.Link onClick={deleteClassroomFromView}>Delete</Card.Link>
       </Card.Body>
     </Card>
   );

--- a/src/components/classrooms/ClassroomCard.jsx
+++ b/src/components/classrooms/ClassroomCard.jsx
@@ -3,16 +3,17 @@
 import React from 'react';
 import Card from 'react-bootstrap/Card';
 import PropTypes from 'prop-types';
-import { useRouter } from 'next/navigation';
+// import { useRouter } from 'next/navigation';
 import deleteClassroomStudentRelationship from '../../api/mergeData';
 
-export default function ClassroomCard({ classroomObj }) {
-  const router = useRouter();
+export default function ClassroomCard({ classroomObj, onUpdate }) {
+  // const router = useRouter();
 
   const deleteClassroomFromView = () => {
     if (window.confirm(`Are you sure you want to delete ${classroomObj.classroom_name}? Deleting this classroom will also delete the students.`)) {
       deleteClassroomStudentRelationship(classroomObj.firebaseKey).then(() => {
-        router.push(`/classroom/manage/`);
+        // router.push(`/classroom/manage/`);
+        onUpdate();
       });
     }
   };
@@ -39,4 +40,5 @@ ClassroomCard.propTypes = {
     grade_level: PropTypes.number,
     firebaseKey: PropTypes.string,
   }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR add a delete functionality to classrooms. A user can now delete a classroom and before the classroom is deleted, the students are first deleted then the classroom. Promise.All makes all of this possible!

At first I was having an issue where the classroom card was still appearing on the page, but when I check the network tab in the dev tools or check Firebase, the record is deleted. Also refreshing the page made the deleted classroom card disappear.

To resolve this issue, I had to fix a typo on the actual promise. I typed `.then(reject)` instead of `.catch(reject)`. I also had to pass in a new prop, onUpdate, that accepts a callback that should trigger when the user clicks delete and confirms the delete, then onUpdate callback will fetch the latest Classroom data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The user can now delete a classroom with all of the associated students.

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->
Run branch locally before merging.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
